### PR TITLE
Fix home path substitution in terminal window titles

### DIFF
--- a/minimal/skel/.extend.bashrc
+++ b/minimal/skel/.extend.bashrc
@@ -5,10 +5,10 @@
 # Change the window title of X terminals
 case ${TERM} in
 	xterm*|rxvt*|Eterm*|aterm|kterm|gnome*|interix|konsole*)
-		PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\007"'
+		PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/\~}\007"'
 		;;
 	screen*)
-		PROMPT_COMMAND='echo -ne "\033_${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\033\\"'
+		PROMPT_COMMAND='echo -ne "\033_${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/\~}\033\\"'
 		;;
 esac
 

--- a/skel/.extend.bashrc
+++ b/skel/.extend.bashrc
@@ -5,10 +5,10 @@
 # Change the window title of X terminals
 case ${TERM} in
 	xterm*|rxvt*|Eterm*|aterm|kterm|gnome*|interix|konsole*)
-		PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\007"'
+		PROMPT_COMMAND='echo -ne "\033]0;${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/\~}\007"'
 		;;
 	screen*)
-		PROMPT_COMMAND='echo -ne "\033_${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/~}\033\\"'
+		PROMPT_COMMAND='echo -ne "\033_${USER}@${HOSTNAME%%.*}:${PWD/#$HOME/\~}\033\\"'
 		;;
 esac
 


### PR DESCRIPTION
The home path substitution with ~ is not working if the ~ is not escaped with \

## Before the fix
![terminal before](https://cloud.githubusercontent.com/assets/195210/19677922/4bbfb89c-9aa4-11e6-88aa-6a51c3c9881a.png)

## After the fix
![terminal after](https://cloud.githubusercontent.com/assets/195210/19677937/5a0646d2-9aa4-11e6-9e2b-e8cdc2f2e339.png)

