### PR TITLE
Disable use_color on dumb terminals

### DIFF
--- a/minimal/skel/.extend.bashrc
+++ b/minimal/skel/.extend.bashrc
@@ -12,7 +12,7 @@ case ${TERM} in
 		;;
 esac
 
-use_color=true
+use_color=false
 
 # Set colorful PS1 only on colorful terminals.
 # dircolors --print-database uses its own built-in database


### PR DESCRIPTION
.extend.bashrc is supposed to turn on color on colorful terminals.
If use_color is true by default, use_color doesn't become false on
dumb terminals.

If use_color is always true, emacs tramp cannot access a remote file via bash.

This pull request will make emacs great again.