### PR TITLE
Adds key shortcuts for moving windows across workspaces

### DIFF
--- a/minimal/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/minimal/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -150,6 +150,10 @@
       <property name="&lt;Control&gt;F3" type="string" value="workspace_3_key"/>
       <property name="&lt;Alt&gt;Insert" type="string" value="add_workspace_key"/>
       <property name="override" type="bool" value="true"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Up" type="string" value="move_window_up_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Down" type="string" value="move_window_down_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Left" type="string" value="move_window_left_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Right" type="string" value="move_window_right_workspace_key"/>
     </property>
   </property>
   <property name="providers" type="array">

--- a/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -151,6 +151,10 @@
       <property name="&lt;Control&gt;F3" type="string" value="workspace_3_key"/>
       <property name="&lt;Alt&gt;Insert" type="string" value="add_workspace_key"/>
       <property name="override" type="bool" value="true"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Up" type="string" value="move_window_up_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Down" type="string" value="move_window_down_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Left" type="string" value="move_window_left_workspace_key"/>
+      <property name="&lt;Shift&gt;&lt;Control&gt;&lt;Alt&gt;Right" type="string" value="move_window_right_workspace_key"/>
     </property>
   </property>
   <property name="providers" type="array">


### PR DESCRIPTION
Inspierd by the same functionality in Ubuntu where navigating between workspaces was done with:
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>←</kbd>: Swith to the left workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>↓</kbd>: Swith to the lower workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>↑</kbd>: Swith to the upper workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>→</kbd>: Swith to the right workspace.

And moving windows between workspaces was done by adding <kbd>Shift</kbd> to the above:
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>←</kbd>: Move window to the left workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>↓</kbd>: Move window to the lower workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>↑</kbd>: Move window to the upper workspace.
* <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>→</kbd>: Move window to the right workspace.

The switch ones were already defined so I tought I'd add the move ones.